### PR TITLE
adds comparisons & isempty check

### DIFF
--- a/src/IntervalUnionArithmetic.jl
+++ b/src/IntervalUnionArithmetic.jl
@@ -5,13 +5,13 @@ using Reexport
 @reexport using IntervalArithmetic
 
 import Base: getindex, ∪, intersect, \, in, isequal
-import Base: +, -, *, /, min, max, ^, log, <, >, exp, sin, cos, tan, sqrt
+import Base: +, -, *, /, min, max, ^, log, <, >, exp, sin, cos, tan, sqrt, ==
 import IntervalArithmetic: union, ∪, hull, bisect, intersect, ⊆, ⊂, setdiff
 
 export
     IntervalUnion, intervalUnion, remove_empties, condense, closeGaps!,
     iscondensed, condense_weak, iscondensed_weak, env, hull, complement, left, right, bisect,
-    intersect, setdiff, \, ⊆, ⊂, isequal, in
+    intersect, setdiff, \, ⊆, ⊂, isequal, in, ==, isempty
 
 
 global MAXINTS = [100]

--- a/src/IntervalUnionArithmetic.jl
+++ b/src/IntervalUnionArithmetic.jl
@@ -4,7 +4,7 @@ using Reexport
 
 @reexport using IntervalArithmetic
 
-import Base: getindex, ∪, intersect, \, in, isequal
+import Base: getindex, ∪, intersect, \, in, isequal, isempty
 import Base: +, -, *, /, min, max, ^, log, <, >, exp, sin, cos, tan, sqrt, ==
 import IntervalArithmetic: union, ∪, hull, bisect, intersect, ⊆, ⊂, setdiff
 

--- a/src/interval_unions.jl
+++ b/src/interval_unions.jl
@@ -66,7 +66,11 @@ getindex(x :: IntervalUnion, ind :: Array{ <: Integer}) = getindex(x.v,ind)
 
 # Remove ∅ from IntervalUnion
 function remove_empties(x :: IntervalUnion)
+
     v = x.v
+
+    if all(isempty.(v)); return intervalUnion(∅); end
+
     Vnew = v[v .!= ∅]
     return IntervalUnion(Vnew)
 end

--- a/src/set_operations.jl
+++ b/src/set_operations.jl
@@ -115,3 +115,28 @@ function in(x :: Real, y :: IntervalUnion)
     end
     return false
 end
+
+function ==(x :: IntervalUnion, y ::IntervalUnion)
+
+    xv = sort(x.v);
+    yv = sort(y.v);
+
+    return all(xv .== yv)
+
+end
+
+function ==(x :: IntervalUnion, y :: Interval)
+    if length(x.v) == 1
+        return x.v[1] == y
+    end
+    return false
+end
+
+==(x :: Interval, y :: IntervalUnion) = y == x
+
+function isempty(x::IntervalUnion)
+    if length(x.v) == 1
+        return isempty(x.v[1])
+    end
+    return false
+end

--- a/test/interval_unions.jl
+++ b/test/interval_unions.jl
@@ -49,6 +49,14 @@ using Test
     @test length(d2.v) == 1
     @test d2.v[1] == interval(1, 3)
 
+    # Comparisons
+    @test intervalUnion(1,2) == Interval(1,2) ∪ ∅
+    @test !(intervalUnion(1,2) == ∅)
+    @test intervalUnion(1,2) == Interval(1,2)
+    @test isempty(intervalUnion(∅))
+
+    @test intervalUnion(∅) == intervalUnion(∅) ∪ ∅
+
 end
 
 @testset "close gaps" begin


### PR DESCRIPTION
Adds `==` and `isempty`

```Julia
julia> using IntervalUnionArithmetic
julia> intervalUnion(1,2) == Interval(1,2) ∪ ∅
true

julia> intervalUnion(1,2) == ∅
false

julia> intervalUnion(∅) == ∅
true

julia> isempty(intervalUnion(∅))
true

julia> intervalUnion(∅) ∪ ∅    # removes all empties but 1
∅ᵤ
```

However, this also now occurs, which might not be desired:

```julia
julia> intervalUnion(1, 2) == interval(1, 2)
true

```

@abraunst thoughts?

closes #17 