### PR TITLE
Delete <:Real constraint

### DIFF
--- a/src/interval_unions.jl
+++ b/src/interval_unions.jl
@@ -24,7 +24,7 @@
 ###
 #   IntervalUnion constructor. Consists of a vector of intervals
 ###
-struct IntervalUnion{T<:Real} <: AbstractInterval{T}
+struct IntervalUnion{T} <: AbstractInterval{T}
     v :: Vector{Interval{T}}
 end
 


### PR DESCRIPTION
I want to use this for `Date` objects, which are not `Real`.